### PR TITLE
Path naming convention should include country names

### DIFF
--- a/chef/cookbooks/supervisor/recipes/default.rb
+++ b/chef/cookbooks/supervisor/recipes/default.rb
@@ -11,7 +11,7 @@ template "/etc/init.d/supervisord" do
   source "supervisord.erb"
 end
 
-template "/var/www/eums/somalia/eums/celery.py" do
+template "/var/www/eums/zimbabwe/eums/celery.py" do
   source "celery.py.erb"
   variables({
      :celery_settings => node['celery_settings']

--- a/chef/cookbooks/supervisor/recipes/default.rb
+++ b/chef/cookbooks/supervisor/recipes/default.rb
@@ -11,7 +11,7 @@ template "/etc/init.d/supervisord" do
   source "supervisord.erb"
 end
 
-template "/var/www/eums/eums/celery.py" do
+template "/var/www/eums/somalia/eums/celery.py" do
   source "celery.py.erb"
   variables({
      :celery_settings => node['celery_settings']

--- a/chef/cookbooks/supervisor/templates/default/supervisord.conf.erb
+++ b/chef/cookbooks/supervisor/templates/default/supervisord.conf.erb
@@ -25,7 +25,7 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 [program:celery]
 command = /var/www/env/eums/bin/celery worker -B --app=eums.celery --loglevel DEBUG
 process_name = eums_celery
-directory = /var/www/eums/
+directory = /var/www/somalia/eums/
 priority = 50
 redirect_stderr = true
 stdout_logfile=/var/log/uwsgi/app/celeryd.log

--- a/chef/cookbooks/supervisor/templates/default/supervisord.conf.erb
+++ b/chef/cookbooks/supervisor/templates/default/supervisord.conf.erb
@@ -23,9 +23,9 @@ serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 
 [program:celery]
-command = /var/www/env/eums/bin/celery worker -B --app=eums.celery --loglevel DEBUG
+command = /var/www/env/zimbabweEums/bin/celery worker -B --app=eums.celery --loglevel DEBUG
 process_name = eums_celery
-directory = /var/www/somalia/eums/
+directory = /var/www/zimbabwe/eums/
 priority = 50
 redirect_stderr = true
 stdout_logfile=/var/log/uwsgi/app/celeryd.log


### PR DESCRIPTION
Since it is going to be more than one application, we thought naming different country instances' paths by country name is a good convention.
